### PR TITLE
Fixes + added live streaming ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Description
 
 This cordova plugin allows to use the ReplayKit framework in iOS.
 The ReplayKit is a new feature in iOS 9.0, that performs screen / microphone recording.
-
+With iOS 10, ReplayKit introduces live streaming as well.
 
 The plugin is referenced by `cordova.plugins.Replay`.
 
@@ -21,7 +21,8 @@ Methods
 -------
 **- startRecording(isMicrophoneEnabled, successCallback, errorCallback)**
 
-* isMicrophoneEnabled [*Bool*]: does the microphone is enabled
+* isRecording [*Bool*]: ~does the microphone is enabled~ Left for legacy. Microphone is always on by default, 
+the user will be prompted to enable microphone or not.
 * successCallback [*Function*]: callback triggered when succeed
 * errorCallback [*Function*]: callback triggered when failed
 
@@ -30,6 +31,35 @@ Methods
 * successCallback [*Function*]: callback triggered when succeed
 * errorCallback [*Function*]: callback triggered when failed
 
+**- isRecording(successCallback, errorCallback)**
+
+* successCallback [*Function*]: callback triggered when succeed, 1st parameter is true when recording
+* errorCallback [*Function*]: callback triggered when failed
+
+**- isAvailable(successCallback, errorCallback)**
+
+* successCallback [*Function*]: callback triggered when succeed, 1st parameter is true if recording is available
+* errorCallback [*Function*]: callback triggered when failed
+
+**- startBroadcast(successCallback, errorCallback)**
+
+* successCallback [*Function*]: callback triggered when succeed
+* errorCallback [*Function*]: callback triggered when failed
+
+**- stopBroadcast(successCallback, errorCallback)**
+
+* successCallback [*Function*]: callback triggered when succeed
+* errorCallback [*Function*]: callback triggered when failed
+
+**- isBroadcasting(successCallback, errorCallback)**
+
+* successCallback [*Function*]: callback triggered when succeed, 1st parameter is true when live streaming
+* errorCallback [*Function*]: callback triggered when failed
+
+**- isBroadcastAvailable(successCallback, errorCallback)**
+
+* successCallback [*Function*]: callback triggered when succeed, 1st parameter is true simply if >iOS 10.0
+* errorCallback [*Function*]: callback triggered when failed
 
 Usage sample
 ------------

--- a/hooks/setswiftversion.js
+++ b/hooks/setswiftversion.js
@@ -1,0 +1,52 @@
+var fs = require('fs');
+var path = require('path');
+
+module.exports = function (context) {
+    var plugins = context.opts.plugins;
+    if (plugins && plugins.length) {
+        if (plugins[0].indexOf('cordova-replay') < 0) {
+            return;
+        }
+    }
+    if (context.opts.cordova.platforms.indexOf('ios') <= -1) {
+            return;
+    }
+
+    var xcode = context.requireCordovaModule('xcode');
+    var iosFolder = context.opts.cordova.project ? context.opts.cordova.project.root : path.join(context.opts.projectRoot, 'platforms', 'ios');
+    var dir;
+    var projectPath;
+    var pbxProject;
+
+    if (context.opts.cordova.platforms.indexOf('ios') < 0) {
+        throw new Error('This plugin expects the ios platform to exist.');
+    }
+
+    // find the project folder by looking for *.xcodeproj
+    dir = fs.readdirSync(iosFolder);
+    if (dir && dir.length) {
+        dir.forEach(function (folder) {
+            if (folder.match(/\.xcodeproj$/)) {
+                projectPath = path.join(iosFolder, folder, 'project.pbxproj');
+            }
+        });
+    }
+
+    if (!projectPath) {
+        throw new Error("Could not find an .xcodeproj folder in: " + iosFolder);
+    }
+
+    if (context.opts.cordova.project) {
+        pbxProject = context.opts.cordova.project.parseProjectFile(context.opts.projectRoot).xcode;
+    } else {
+        pbxProject = xcode.project(projectPath);
+        pbxProject.parseSync();
+    }
+
+    // set swift to 3.0
+    pbxProject.addBuildProperty('SWIFT_VERSION', '3.0');
+
+    // write the updated project file
+    fs.writeFileSync(projectPath, pbxProject.writeSync());
+
+};

--- a/plugin.xml
+++ b/plugin.xml
@@ -15,6 +15,7 @@
     </js-module>
 
     <platform name="ios">
+        <hook type="after_plugin_add" src="hooks/setswiftversion.js" />
         <config-file parent="/*" target="config.xml">
             <feature name="CordovaReplay">
                 <param name="ios-package" value="CordovaReplay"/>

--- a/src/ios/CDVCordovaReplay.swift
+++ b/src/ios/CDVCordovaReplay.swift
@@ -1,76 +1,185 @@
 import ReplayKit
 import UIKit
 
-@objc(CordovaReplay) class CordovaReplay : CDVPlugin, RPScreenRecorderDelegate, RPPreviewViewControllerDelegate {
+@available(iOS 10.0, *)
+class BroadcastController : RPBroadcastController {
+    // using this singleton to store a single instance of a broadcastcontroller
+    static let controller = BroadcastController()
+}
 
-  weak var previewViewController: RPPreviewViewController?
-  var CDVWebview:UIWebView;
-
-  // This is just called if <param name="onload" value="true" /> in plugin.xml.
-    init(webView: UIWebView) {
-        NSLog("CordovaReplay#init()")
-        self.CDVWebview = webView
-//        super.init(webView: webView)
-    }
-
-  func startRecording(_ command: CDVInvokedUrlCommand) {
+@objc(CordovaReplay) class CordovaReplay : CDVPlugin, RPScreenRecorderDelegate, RPPreviewViewControllerDelegate, RPBroadcastActivityViewControllerDelegate {
+    
+    weak var previewViewController: RPPreviewViewController?
+    var CDVWebview:UIWebView;
+    
     let recorder = RPScreenRecorder.shared()
-    recorder.delegate = self
-//    let isMicrophoneEnabled = command.argument(at: 0) as! Bool
-    if #available(iOS 10.0, *) {
-        recorder.startRecording() { [unowned self] (error) in
+
+    // This is just called if <param name="onload" value="true" /> in plugin.xml.
+    init(webView: UIWebView) {
+        self.CDVWebview = webView
+        //super.init(webView: webView)
+    }
+    
+    func isAvailable(_ command: CDVInvokedUrlCommand) {
+        if #available(iOS 10.0, *) {
+            let available = recorder.isAvailable;
+            let pluginResult = CDVPluginResult(status:CDVCommandStatus_OK, messageAs: available)
+            self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
+        } else {
+            let pluginResult = CDVPluginResult(status:CDVCommandStatus_OK, messageAs: false)
+            self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
+        }
+    }
+    
+    func isRecording(_ command: CDVInvokedUrlCommand) {
+        let recording = recorder.isRecording;
+        let pluginResult = CDVPluginResult(status:CDVCommandStatus_OK, messageAs: recording)
+        self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
+    }
+    
+    func startRecording(_ command: CDVInvokedUrlCommand) {
+        recorder.delegate = self
+        // just turn on the microphone, the user will have the option to record with microphone
+        recorder.isMicrophoneEnabled = true
+        // camera is an iOS10 feature
+        if #available(iOS 10.0, *) {
+            // for camera usage, we'd also need to recorder.cameraPreviewView somewhere?
+            //recorder.isCameraEnabled = command.argumentAtIndex(0) as! Bool
+        }
+        if #available(iOS 10.0, *) {
+            recorder.startRecording() { [unowned self] (error) in
+                var pluginResult:CDVPluginResult
+                if let unwrappedError = error {
+                    print(error?.localizedDescription as Any);
+                    pluginResult = CDVPluginResult(status:CDVCommandStatus_ERROR, messageAs: unwrappedError.localizedDescription)
+                    self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
+                } else {
+                    pluginResult = CDVPluginResult(status:CDVCommandStatus_OK)
+                    self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
+                }
+            }
+        } else {
+            // recorder not available iOS <10.0
             var pluginResult:CDVPluginResult
-            if let unwrappedError = error {
-                pluginResult = CDVPluginResult(status:CDVCommandStatus_ERROR, messageAs: unwrappedError.localizedDescription)
-                pluginResult.setKeepCallbackAs(true)
-                self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
-            } else {
+            pluginResult = CDVPluginResult(status:CDVCommandStatus_ERROR)
+            self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
+        }
+    }
+    
+    func stopRecording(_ command: CDVInvokedUrlCommand) {
+        recorder.stopRecording { [unowned self] (preview, error) in
+            var pluginResult:CDVPluginResult
+            if let unwrappedPreview = preview {
+                unwrappedPreview.previewControllerDelegate = self
+                self.previewViewController = unwrappedPreview
+                self.previewViewController!.modalPresentationStyle = UIModalPresentationStyle.fullScreen;
+                self.viewController.present(unwrappedPreview, animated: true, completion: nil);
                 pluginResult = CDVPluginResult(status:CDVCommandStatus_OK)
                 pluginResult.setKeepCallbackAs(true)
                 self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
             }
+            if let unwrappedError = error {
+                pluginResult = CDVPluginResult(status:CDVCommandStatus_ERROR, messageAs: unwrappedError.localizedDescription)
+                pluginResult.setKeepCallbackAs(true)
+                self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
+            }
         }
-    } else {
-        // ???
-        // recorder.startRecording not defined iOS <10.0
-        var pluginResult:CDVPluginResult
-        pluginResult = CDVPluginResult(status:CDVCommandStatus_ERROR)
-        pluginResult.setKeepCallbackAs(true)
+    }
+    
+    func previewControllerDidFinish(_ previewController: RPPreviewViewController) {
+        previewViewController?.dismiss(animated: true)
+    }
+
+    /* https://www.appcoda.com/replaykit-live-broadcast/ */
+    func isBroadcastAvailable(_ command: CDVInvokedUrlCommand) {
+        var available = false;
+        // Note: there is no isAvailable property, so we only check if we're on iOS10
+        if #available(iOS 10.0, *) {
+            available = true;
+        }
+        let pluginResult = CDVPluginResult(status:CDVCommandStatus_OK, messageAs: available)
         self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
     }
-  }
-
-  func stopRecording(_ command: CDVInvokedUrlCommand) {
-    let recorder = RPScreenRecorder.shared()
-
-    recorder.stopRecording { [unowned self] (preview, error) in
-      var pluginResult:CDVPluginResult
-      if let unwrappedPreview = preview {
-        unwrappedPreview.previewControllerDelegate = self
-        self.previewViewController = unwrappedPreview
-        self.previewViewController!.modalPresentationStyle = UIModalPresentationStyle.fullScreen;
-        self.viewController.present(unwrappedPreview, animated: true, completion: nil);
-        pluginResult = CDVPluginResult(status:CDVCommandStatus_OK)
-        pluginResult.setKeepCallbackAs(true)
+    func isBroadcasting(_ command: CDVInvokedUrlCommand) {
+        var recording = false;
+        if #available(iOS 10.0, *) {
+            recording = BroadcastController.controller.isBroadcasting
+        }
+        let pluginResult = CDVPluginResult(status:CDVCommandStatus_OK, messageAs: recording)
         self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
-      }
-      if let unwrappedError = error {
-        pluginResult = CDVPluginResult(status:CDVCommandStatus_ERROR, messageAs: unwrappedError.localizedDescription)
-        pluginResult.setKeepCallbackAs(true)
-        self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
-      }
     }
-  }
+    
+    weak var broadcastCommand:CDVInvokedUrlCommand?
+    func startBroadcast(_ command: CDVInvokedUrlCommand) {
+        if #available(iOS 10.0, *) {
+            // pass the cordova command to broadcastactivityviewcontroller
+            self.broadcastCommand = command;
+            RPBroadcastActivityViewController.load { broadcastAVC, error in
+                guard error == nil else {
+                    print("Cannot load Broadcast Activity View Controller.")
+                    var pluginResult:CDVPluginResult
+                    pluginResult = CDVPluginResult(status:CDVCommandStatus_ERROR, messageAs: error?.localizedDescription)
+                    self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
+                    return
+                }
+                if let broadcastAVC = broadcastAVC {
+                    broadcastAVC.delegate = self
+                    self.viewController.present(broadcastAVC, animated: true, completion: {
+                        // broadcastactivityviewcontroller will perform the callback when the broadcast starts (or fails)
+                    })
+                }
+            }
+        }
+    }
+    
+    @available(iOS 10.0, *)
+    func broadcastActivityViewController(_ broadcastActivityViewController: RPBroadcastActivityViewController,
+                                         didFinishWith broadcastController: RPBroadcastController?,
+                                         error: Error?)
+    {
+        let command = self.broadcastCommand;
+        guard error == nil else {
+            broadcastActivityViewController.dismiss(animated: true)
+            print(error?.localizedDescription ?? "Broadcast Activity Controller is not available.")
+            var pluginResult:CDVPluginResult
+            pluginResult = CDVPluginResult(status:CDVCommandStatus_ERROR, messageAs: error?.localizedDescription)
+            self.commandDelegate!.send(pluginResult, callbackId:command?.callbackId)
+            return
+        }
+        broadcastActivityViewController.dismiss(animated: true) {
+            broadcastController?.startBroadcast { error in
+                if error == nil {
+                    print("Broadcast started successfully!")
+                    var pluginResult:CDVPluginResult
+                    pluginResult = CDVPluginResult(status:CDVCommandStatus_OK)
+                    self.commandDelegate!.send(pluginResult, callbackId:command?.callbackId)
+                } else {
+                    var pluginResult:CDVPluginResult
+                    pluginResult = CDVPluginResult(status:CDVCommandStatus_ERROR, messageAs: error?.localizedDescription)
+                    self.commandDelegate!.send(pluginResult, callbackId:command?.callbackId)
+                }
+            }
+        }
+    }
 
-  func previewControllerDidFinish(previewController: RPPreviewViewController) {
-    previewController.dismiss(animated: true, completion: nil)
-  }
-
-  override func onReset() {
-    NSLog("CordovaReplay#onReset() | doing nothing")
-  }
-
-  override func onAppTerminate() {
-    NSLog("CordovaReplay#onAppTerminate() | doing nothing")
-  }
+    func stopBroadcast(_ command: CDVInvokedUrlCommand) {
+        if #available(iOS 10.0, *) {
+            let controller = BroadcastController.controller;
+            controller.finishBroadcast { error in
+                if error == nil {
+                    print("Broadcast ended")
+                    var pluginResult:CDVPluginResult
+                    pluginResult = CDVPluginResult(status:CDVCommandStatus_OK)
+                    pluginResult.setKeepCallbackAs(true)
+                    self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
+                } else {
+                    var pluginResult:CDVPluginResult
+                    pluginResult = CDVPluginResult(status:CDVCommandStatus_ERROR, messageAs: error?.localizedDescription)
+                    pluginResult.setKeepCallbackAs(true)
+                    self.commandDelegate!.send(pluginResult, callbackId:command.callbackId)
+                }
+            }
+        }
+    }
 }
+

--- a/www/CordovaReplay.js
+++ b/www/CordovaReplay.js
@@ -1,13 +1,30 @@
 var exec = require('cordova/exec');
 
-var Replay = function() {};
-
-Replay.startRecording = function(isMicrophoneEnabled, success, error) {
-    exec(success, error, "CordovaReplay", "startRecording", [isMicrophoneEnabled]);
-};
-
-Replay.stopRecording = function(success, error) {
-    exec(success, error, "CordovaReplay", "stopRecording");
+var Replay = {
+    isAvailable: function (success, error) {
+        exec(success, error, 'CordovaReplay', 'isAvailable');
+    },
+    startRecording: function (isMicrophoneEnabled, success, error) {
+        exec(success, error, "CordovaReplay", "startRecording", [isMicrophoneEnabled]);
+    },
+    stopRecording: function (success, error) {
+        exec(success, error, "CordovaReplay", "stopRecording");
+    },
+    isRecording: function (success, error) {
+        exec(success, error, "CordovaReplay", "isRecording");
+    },
+    startBroadcast: function (success, error) {
+        exec(success, error, "CordovaReplay", "startBroadcast");
+    },
+    stopBroadcast: function (success, error) {
+        exec(success, error, "CordovaReplay", "stopBroadcast");
+    },
+    isBroadcasting: function (success, error) {
+        exec(success, error, "CordovaReplay", "isBroadcasting");
+    },
+    isBroadcastAvailable: function (success, error) {
+        exec(success, error, "CordovaReplay", "isBroadcastAvailable");
+    }
 };
 
 module.exports = Replay;


### PR DESCRIPTION
Updated to Swift 3 (and added a hook to enable it). Fixed hanging when dismissing the recording. Also added live broadcasting.
 
Warning when testing this plugin: iOS11 itself is incredibly buggy with ReplayKit so bugs might be the fault of the OS itself. 